### PR TITLE
Sensible Error message from loading a bad config file

### DIFF
--- a/azure_guardrails/shared/config.py
+++ b/azure_guardrails/shared/config.py
@@ -207,10 +207,7 @@ DEFAULT_CONFIG = get_default_config()
 
 def get_config_from_file(config_file: str, exclude_services: list = None) -> Config:
     with open(config_file, "r") as yaml_file:
-        try:
-            config_cfg = yaml.safe_load(yaml_file)
-        except yaml.YAMLError as exc:
-            logger.critical(exc)
+        config_cfg = yaml.safe_load(yaml_file)
     # Policies to exclude
     cfg_exclude_policies = config_cfg.get("exclude_policies", None)
 

--- a/test/files/bad-config.yml
+++ b/test/files/bad-config.yml
@@ -1,0 +1,6 @@
+# Specify Azure Policy Definition displayNames that you want to exclude from the results
+exclude_policies:
+  Data Factory:
+    - [Preview]: Azure Data Factory should use a Git repository for source control
+#    - "[Preview]: Azure Data Factory should use a Git repository for source control"
+

--- a/test/shared/test_config.py
+++ b/test/shared/test_config.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import yaml
 import json
+from yaml.constructor import ConstructorError
 import logging
 from azure_guardrails.shared import utils
 from azure_guardrails.shared.config import get_config_template, Config, get_config_from_file, get_default_config
@@ -87,4 +88,12 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(config.is_excluded("App Configuration", "App Configuration should use private link"))
         self.assertTrue(config.is_excluded("Cosmos DB", "CosmosDB accounts should use private link"))
 
-
+    def test_gh_44_bad_config_file(self):
+        bad_config_file = os.path.abspath(os.path.join(
+            os.path.dirname(__file__),
+            os.path.pardir,
+            "files",
+            "bad-config.yml"
+        ))
+        with self.assertRaises(yaml.constructor.ConstructorError):
+            config = get_config_from_file(bad_config_file)


### PR DESCRIPTION
## What does this PR do?

* Fixes #44 - error message from loading bad config file is sensible now

## Completion checklist

- [x] Additions and changes have unit tests
- [x] Unit tests, Pylint, security testing, and Integration tests are passing. GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
