### PR TITLE
Add policy type counts and provider.tf instructions to command output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Repository specific
+provider.tf
+
 # IDEs
 .idea
 .vscode

--- a/azure_guardrails/command/generate_terraform.py
+++ b/azure_guardrails/command/generate_terraform.py
@@ -74,6 +74,7 @@ def generate_terraform(
     # Policy Initiative Category
     category = "Testing"
 
+    # Read the config file
     if parameters_config_file:
         parameters_config = utils.read_yaml_file(parameters_config_file)
     else:
@@ -88,17 +89,13 @@ def generate_terraform(
         no_params=no_params,
         params_optional=params_optional,
         params_required=params_required,
+        category=category,
+        enforcement_mode=enforcement_mode,
         verbosity=verbosity
     )
 
-    terraform_content = terraform.generate_terraform(enforcement_mode=enforcement_mode, category=category)
-
     output_file = os.path.join(output_directory, terraform.file_name)
-    if os.path.exists(output_file):
-        logger.info("%s exists. Removing the file and replacing its contents." % output_file)
-        os.remove(output_file)
-    with open(output_file, "w") as f:
-        f.write(terraform_content)
+    terraform.create_terraform_file(output_file=output_file)
 
     # Print success message
     terraform.print_success_message(output_file=output_file, output_directory=output_directory, enforcement_mode=enforcement_mode)

--- a/test/terraform/test_terraform_guardrails.py
+++ b/test/terraform/test_terraform_guardrails.py
@@ -1,0 +1,32 @@
+import unittest
+import json
+from azure_guardrails.shared.config import get_default_config
+from azure_guardrails.terraform.guardrails import TerraformGuardrails
+
+
+class AzurePoliciesTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        config = get_default_config(exclude_services=[])
+        self.terraform = TerraformGuardrails(
+            service="Key Vault",
+            config=config,
+            subscription="example",
+            management_group="",
+            parameters_config={},
+            no_params=True,
+            params_optional=False,
+            params_required=False,
+            category="Testing",
+            enforcement_mode=True,
+            verbosity=3
+        )
+
+    def test_policy_metadata(self):
+        policy_id_pairs = self.terraform.policy_id_pairs()
+        print(json.dumps(policy_id_pairs, indent=4))
+        policy_names = self.terraform.policy_names()
+        print(json.dumps(policy_names, indent=4))
+        policy_ids = self.terraform.policy_ids()
+        print(json.dumps(policy_ids, indent=4))
+        self.assertTrue(len(policy_names) == len(policy_ids))
+

--- a/test/terraform/test_terraform_no_params.py
+++ b/test/terraform/test_terraform_no_params.py
@@ -32,6 +32,8 @@ class TerraformTemplateNoParamsTestCase(unittest.TestCase):
         kv_policy_id_pairs = self.kv_azure_policies.get_all_policy_ids_sorted_by_service(
             no_params=True
         )
+        import json
+        print(json.dumps(kv_policy_id_pairs, indent=4))
         self.kv_terraform_template = TerraformTemplateNoParams(
             policy_id_pairs=kv_policy_id_pairs,
             subscription_name=subscription,


### PR DESCRIPTION
## What does this PR do?

* Fixes #69 - counts policies by enforcement type and parameter requirements in success message
* Fixes #68 - adds instructions to create the `provider.tf` file to avoid errors

## Completion checklist

- [x] Additions and changes have unit tests
- [x] Unit tests, Pylint, security testing, and Integration tests are passing. GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
